### PR TITLE
Catalyst detailed log v2.1.0 rc5

### DIFF
--- a/core/src/main/scala/org/apache/spark/DebugMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/DebugMetrics.scala
@@ -5,23 +5,24 @@ package org.apache.spark
   */
 object DebugMetrics {
 
-  case class jobdetails(query: String, taskType : String, jobId : Int, stageId : Int)
+  case class jobdetails(query: String, taskType : String, jobId : Int, stageId : Int, taskId: Long)
   val s = new ThreadLocal[jobdetails];
 
   def get() = {
     if(s.get() == null)
-      jobdetails("unknown","unknown",-1,-1)
+      jobdetails("unknown","unknown",-1,-1,-1)
     else
       s.get()
   }
 
-  def set(query : String, taskType : String, jobId : Int, stageId : Int) = {
-    s.set(jobdetails(query,taskType,jobId,stageId))
+  def set(query : String, taskType : String, jobId : Int, stageId : Int, taskId : Long) = {
+    s.set(jobdetails(query,taskType,jobId,stageId,taskId))
   }
 
   def getTaskType() = get().taskType
   def getJobId() = get.jobId
   def getStageId() = get.stageId
   def getQuery() = get().query
+  def getTaskId() = get().taskId
 
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -73,7 +73,7 @@ private[spark] class ResultTask[T, U](
   override def runTask(context: TaskContext): U = {
     // Deserialize the RDD and the func using the broadcast variables.
     val q = SparkEnv.get.conf.get("spark.app.name","unknown")
-    DebugMetrics.set(q, "ResultTask",jobId.getOrElse(-1),stageId)
+    DebugMetrics.set(q, "ResultTask",jobId.getOrElse(-1),stageId,context.taskAttemptId())
     val threadMXBean = ManagementFactory.getThreadMXBean
     val deserializeStartTime = System.currentTimeMillis()
     val deserializeStartCpuTime = if (threadMXBean.isCurrentThreadCpuTimeSupported) {

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -77,7 +77,7 @@ private[spark] class ShuffleMapTask(
   override def runTask(context: TaskContext): MapStatus = {
     // Deserialize the RDD using the broadcast variable.
     val q = SparkEnv.get.conf.get("spark.app.name","unknown")
-    DebugMetrics.set(q,"shuffleTask",jobId.getOrElse(-1),stageId)
+    DebugMetrics.set(q,"shuffleTask",jobId.getOrElse(-1),stageId,context.taskAttemptId)
     val threadMXBean = ManagementFactory.getThreadMXBean
     val deserializeStartTime = System.currentTimeMillis()
     val deserializeStartCpuTime = if (threadMXBean.isCurrentThreadCpuTimeSupported) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1002,14 +1002,26 @@ object CodeGenerator extends Logging {
           val j = DebugMetrics.getJobId()
           val s = DebugMetrics.getStageId()
           val t = DebugMetrics.getTaskType()
-          val fname = s"${q}_jobid_${j}_stageid_${s}_${t}_${cnt}_execid_${executorId}"
+          val taskId = DebugMetrics.getTaskId()
+          val hc = code.hashCode()
+          val fname = s"${q}_jobid_${j}_stageid_${s}_taskid_${taskId}_${t}_${cnt}_execid_${executorId}_${hc}"
           var code1 : CodeAndComment = code;
 
           try {
-            val source = scala.io.Source.fromFile(s"/tmp/catalyst-input/${fname}.java")
+            def getFilesMatchingRegex(dir: String, regex: util.matching.Regex) = {
+              new java.io.File(dir).listFiles
+                .filter(file => regex.findFirstIn(file.getName).isDefined)
+                .head
+            }
+            val regexp = ".*" + code1.hashCode() +  "\\.java"
+            val mFile = getFilesMatchingRegex("/tmp/catalyst-input", regexp.r)
+            val mFileName = mFile.getPath()
+            println(s"Kavana ${fname} matched ${mFileName}")
+            val source = scala.io.Source.fromFile(mFileName)
             val lines = try source.mkString finally source.close()
             code1 = new CodeAndComment(lines,Map[String,String]())
-            println(s"MADHU using Custom Java code for ${fname} executor id ${executorId}")
+            val newHc = code1.hashCode()
+            println(s"Kavana using Custom Java code for ${fname} with HashCode ${newHc}")
           }
           catch {
             case _ : Throwable => {}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -502,4 +502,4 @@ case class CollapseCodegenStages(conf: SQLConf) extends Rule[SparkPlan] {
       plan
     }
   }
-}
+} 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Removed job/stage tags for processNext in WholeStageCodegenExec.scala
2. Added taskId and catalyst checksum information as part of catalyst file name.
3. Added implementation to check for catalyst file with the same checksum under /tmp/catalyst-input directory and use it.

## How was this patch tested?

Tested using Spark Unit testcases and TPCDS benchmarks
